### PR TITLE
Fix rounding error

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -359,7 +359,7 @@ function addNewRecord() {
     var input = $('#temperature').val();
     var newRecord = {
         datetime: firebase.firestore.Timestamp.fromDate(moment($('#datetime').val()).toDate()),
-        temperature: Math.round(100 * (temperatureUnit == 'F' ? Math.round(input) : celsiusToFarenheit(input))) / 100,
+        temperature: temperatureUnit == 'F' ? Math.round(input * 100) / 100 : celsiusToFarenheit(input),
         sick: false
     };
 


### PR DESCRIPTION
The issue was that when we were entering a Farenheit value, we were running Math.round(value), which removes the decimal points. This was changed to Math.round(value * 100) / 100, which retains the decimal points. Also removed the Math.round surrounding the whole line (362) as this was redundant given the celsiusToFarenheit function does its own rounding. 